### PR TITLE
Update marathon.json

### DIFF
--- a/marathon.json
+++ b/marathon.json
@@ -47,6 +47,7 @@
     "taskLostBehavior": "WAIT_FOREVER",
     "relaunchEscalationTimeoutSeconds": 120
   },
+  "unreachableStrategy": "disabled",
   "env": {
     "MINIO_ACCESS_KEY": "miniotest",
     "MINIO_SECRET_KEY": "secret123"


### PR DESCRIPTION
It seems that:
  "unreachableStrategy": "disabled"
is needed with "residency" enabled.

Unfortunately, 1.9 UI has a bug preventing use of this setting, you need to use CLI.